### PR TITLE
Add HeadshotCraft to AI Headshot Generator

### DIFF
--- a/Category/AI_Headshot_Generator.md
+++ b/Category/AI_Headshot_Generator.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for ai headshot generator. Contribute to this
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Aragon AI | Realistic AI Headshot Generator for Professionals | [https://www.aragon.ai/](https://www.aragon.ai/) |
+| HeadshotCraft | Turn one selfie into 50+ studio-quality headshots | [https://headshotcraft.com](https://headshotcraft.com) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## Summary
- add HeadshotCraft to the AI Headshot Generator category

HeadshotCraft turns one selfie into 50+ studio-quality headshots for LinkedIn, resumes, and team pages in under 2 minutes.