### PR TITLE
Add ProfileReadme to Career Tools

### DIFF
--- a/Category/Career.md
+++ b/Category/Career.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for career. Contribute to this list via our [
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Braudit AI | Get Free Career Insights & Guidance with Braudit | [https://braudit.app/](https://braudit.app/) |
+| ProfileReadme | Template-driven profile pages and developer bio builder | [https://f726103e.profilereadme.pages.dev](https://f726103e.profilereadme.pages.dev) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Add ProfileReadme as a template-driven profile page and developer bio builder.