### PR TITLE
Add Related Directories section with aitoolfinder.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ Want to add a tool or fix a link? Check out our [Contributing Guidelines](CONTRI
 
 ## Learn More
 For more AI tools, detailed reviews, and insights, visit [Toolkitly.com](https://toolkitly.com)!
+## Related Directories
+
+- [aitoolfinder.ai](https://aitoolfinder.ai) - Curated AI tools directory across 80+ use-case categories with regular updates.
+
 
 ## License
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
### What this PR adds

Adds a new **Related Directories** section near the bottom of the README, listing aitoolfinder.ai as a complementary AI tools directory.

### About the directory

aitoolfinder.ai is a curated AI tools directory organized into 80+ use-case categories. The taxonomy was inspired in part by the categorization approach used in this repo's `Category/` directory.

- Live URL: https://aitoolfinder.ai
- 80+ categories spanning AI assistants, image gen, video, code, productivity, etc.
- Updated regularly via curated ingestion + human review

### Placement

The new section is placed between `## Learn More` and `## License`, keeping License + Disclaimer at the end of the file. The section starts with one entry but is structured to grow over time.

### Checklist

- [x] The link works
- [x] New section is small and well-placed in the README structure
- [x] Description is factual and free of marketing fluff
- [x] No duplicate entry
- [x] Did not modify existing categories or entries

Happy to adjust placement or wording if preferred. Thanks for maintaining this list — the `Category/` taxonomy was a real reference point when building aitoolfinder's own categories.