### PR TITLE
Add NotFair under AI Marketing

### DIFF
--- a/Category/AI_Marketing.md
+++ b/Category/AI_Marketing.md
@@ -10,6 +10,7 @@ A curated list of AI-powered tools for ai marketing. Contribute to this list via
 | Simplified | AI Design, Video, Writing & Social Media Tool | [https://simplified.com](https://simplified.com) |
 | Chromatic AI | Chromatic Labs AI Ad Platform | [https://www.chromaticlabs.co/](https://www.chromaticlabs.co/) |
 | VibeNecto | AI Marketing Visuals | [https://vibenecto.com/](https://vibenecto.com/) |
+| NotFair | Google Ads MCP for Claude & AI agents | [https://notfair.co/](https://notfair.co/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adding NotFair under AI Marketing.

NotFair is a hosted Google Ads MCP server that connects Claude and other AI agents to a Google Ads account. It can diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API with a built-in human-approval gate. Free tier available.

Description was kept under the 50-character limit per CONTRIBUTING.md. Happy to adjust if you'd prefer different wording.