### PR TITLE
Add ARC-Neuron LLMBuilder

### DIFF
--- a/Category/Developer_Tools.md
+++ b/Category/Developer_Tools.md
@@ -1,4 +1,5 @@
 # Developer Tools Tools
+- [ARC-Neuron LLMBuilder](https://github.com/GareBear99/ARC-Neuron-LLMBuilder) - Local-first AI model lifecycle framework for benchmark receipts, candidate/incumbent model promotion, archive-ready lineage, and governed small-model improvement.
 
 A curated list of AI-powered tools for developer tools. Contribute to this list via our [Contributing Guidelines](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/CONTRIBUTING.md).
 


### PR DESCRIPTION
Adds ARC-Neuron LLMBuilder as a local-first AI model lifecycle / governance tool.

ARC-Neuron focuses on deterministic small-model promotion, benchmark receipts, candidate/incumbent comparison, archive-ready lineage, and evidence-first local AI improvement.

Main repo:
https://github.com/GareBear99/ARC-Neuron-LLMBuilder

Protected v1.0.0 release baseline:
https://github.com/GareBear99/arc-neuron-llmbuilder-v1.0.0

Suggested placement:
- AI Developer Tools
- Local AI Tools
- LLMOps / Model Lifecycle
- Trustworthy AI / Provenance
- Reproducible AI
- Small Language Model Governance
