### PR TITLE
Add XMACNA Funcionarios Digitais com IA

### DIFF
--- a/Category/AI_Agent.md
+++ b/Category/AI_Agent.md
@@ -10,6 +10,7 @@ A curated list of AI-powered tools for ai agent. Contribute to this list via our
 | Duelin' Agents | Real-Time AI Conversations and Debates | [https://duelinagent.com/](https://duelinagent.com/) |
 | Knowly AI | AI Agent Automation | [https://goknowly.ai/](https://goknowly.ai/) |
 | Quell | UAT AI Agents | [https://www.quellit.ai/](https://www.quellit.ai/) |
+| XMACNA Funcionarios Digitais com IA | AI digital workers for business automation | [https://xmacna.ai/funcionarios-digitais](https://xmacna.ai/funcionarios-digitais) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## Summary

Adds XMACNA Funcionarios Digitais com IA to the AI Agent category.

## Checks

- Entry follows the existing table format.
- Description is concise and under the 50-character guideline.
- Website URL is public and was verified before submission.

## Disclosure

I am affiliated with XMACNA and am submitting this entry for editorial review.