### PR TITLE
Add CreatorSkills to Creator Platform category

### DIFF
--- a/Category/Creator_Platform.md
+++ b/Category/Creator_Platform.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for creator platform. Contribute to this list
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Beacons AI | AI-Powered Creator Platform | [https://beacons.ai/](https://beacons.ai/) |
+| CreatorSkills | AI skills marketplace for creators | [https://creatorskills.co](https://creatorskills.co) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## What's being added

[CreatorSkills](https://creatorskills.co) — a marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.

## Why it fits

CreatorSkills belongs in the **Creator Platform** category alongside Beacons AI. It's specifically built for content creators and provides AI skills (prompts/instructions) to help them with their workflows.