### PR TITLE
Add Albis to Search AI Platform tools

### DIFF
--- a/Category/Search_AI_Platform.md
+++ b/Category/Search_AI_Platform.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for search ai platform. Contribute to this li
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Elastic | The Search AI Platform for Enterprise Solutions | [https://www.elastic.co/](https://www.elastic.co/) |
+| Albis | AI news feed gap discovery and context | [https://www.albis.news/?utm_source=github&utm_medium=public_catalog&utm_campaign=toolkitly_awesome_ai_tools](https://www.albis.news/?utm_source=github&utm_medium=public_catalog&utm_campaign=toolkitly_awesome_ai_tools) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds Albis as a public AI-assisted news discovery/context tool.

Albis helps readers compare what their feed may have missed and notice coverage/context gaps. It is not submitted as a fact-checking authority or endorsement claim; it is positioned as an exploratory search/news context tool.

Submitted on behalf of Albis.