### PR TITLE
Add NotFair open-source SEO & paid-ads Claude Code skills

### DIFF
--- a/Category/AI_Marketing.md
+++ b/Category/AI_Marketing.md
@@ -10,6 +10,7 @@ A curated list of AI-powered tools for ai marketing. Contribute to this list via
 | Simplified | AI Design, Video, Writing & Social Media Tool | [https://simplified.com](https://simplified.com) |
 | Chromatic AI | Chromatic Labs AI Ad Platform | [https://www.chromaticlabs.co/](https://www.chromaticlabs.co/) |
 | VibeNecto | AI Marketing Visuals | [https://vibenecto.com/](https://vibenecto.com/) |
+| NotFair | Open-source SEO & ads skills for Claude | [https://github.com/nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Thanks for maintaining this list — it's a great resource.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair), an open-source set of Claude Code agent skills for SEO and paid advertising (~2.9k stars, MIT license). It covers SEO site analysis, keyword research, meta tags, schema markup, GEO optimization, and content writing, as well as Google Ads audits and Meta Ads performance reviews.

The project connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

I've placed it in the AI Marketing category to sit alongside the other ad and marketing tools already listed there. Happy to adjust the wording, move it to a different section, or trim the description if needed.