### PR TITLE
Add Sparkiz.ai to AI-Powered Video Ad Creator

### DIFF
--- a/Category/AI-Powered_Video_Ad_Creator.md
+++ b/Category/AI-Powered_Video_Ad_Creator.md
@@ -4,6 +4,7 @@ A curated list of AI-powered tools for ai-powered video ad creator. Contribute t
 
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
+| Sparkiz.ai | AI video ads from a product link in 60s | [https://sparkiz.ai](https://sparkiz.ai) |
 | VidAU AI | Create Winning Video Ads with AI | Fast & Easy | [https://www.vidau.ai/](https://www.vidau.ai/) |
 | Glato AI | AI Short Video Ads Generator - Create 100s in Minutes | [https://glato.ai/](https://glato.ai/) |
 


### PR DESCRIPTION
Adding **Sparkiz.ai** to the AI-Powered Video Ad Creator category. Turns a product link into a ready-to-launch AI video ad (avatar, voiceover, captions) in under 60 seconds, for ecommerce. https://sparkiz.ai (follows the existing table format, description under 50 chars).