### PR TITLE
Add Tudo and Telo to Toolkitly AI tools

### DIFF
--- a/Category/Healthcare.md
+++ b/Category/Healthcare.md
@@ -12,6 +12,7 @@ A curated list of AI-powered tools for healthcare. Contribute to this list via o
 | SelfDecode | Transform Your Health with AI-Powered DNA Analysis | [https://selfdecode.com/](https://selfdecode.com/) |
 | Futureheal | Revolutionizing Healthcare with AI Diagnostics | [https://futureheal.com/](https://futureheal.com/) |
 | Journable | Journable Free AI Calorie & Fitness Tracker App | [https://www.journable.com/](https://www.journable.com/) |
+| Telo | AI wellness and recovery insights | [https://blynkai.app/telo/](https://blynkai.app/telo/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)

--- a/Category/Productivity.md
+++ b/Category/Productivity.md
@@ -7,6 +7,7 @@ A curated list of AI-powered tools for productivity. Contribute to this list via
 | Pop AI | The AI Tool to Chat with Your Documents & Images | [https://popai.saaslink.net/9qUEYP](https://popai.saaslink.net/9qUEYP) |
 | WorkToDo | WorkToDo: Personal CRM & Task Management for Business Productivity | [https://www.worktodo.today](https://www.worktodo.today) |
 | Second Brain | Productivity AI | [https://www.thesecondbrain.io/](https://www.thesecondbrain.io/) |
+| Tudo | AI task capture and personal planning | [https://blynkai.app/tudo/](https://blynkai.app/tudo/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds two BlynkAI iOS AI tools to matching category pages:

- Tudo in Productivity
- Telo in Healthcare

Follow-up to #51.