### PR TITLE
Add Cloud Clipboard Video (cv.cm/v) to AI Video

### DIFF
--- a/Category/AI_Video.md
+++ b/Category/AI_Video.md
@@ -8,6 +8,7 @@ A curated list of AI-powered tools for ai video. Contribute to this list via our
 | Hailuo AI | AI Video Creation | [https://hailuoai.video/](https://hailuoai.video/) |
 | PVID | Free AI video generator | [https://pvid.app/](https://pvid.app/) |
 | Rask AI | Translate & Dub Videos in 130+ Languages | [https://www.rask.ai/](https://www.rask.ai/) |
+| Cloud Clipboard Video | Queue-free Seedance 2.0 video, real-face | [https://cv.cm/v](https://cv.cm/v) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds one AI video tool to `Category/AI_Video.md`, following the contributing guidelines (Name | Description ≤50 chars | Website).

**Cloud Clipboard Video** — Queue-free Seedance 2.0 text/image-to-video with real-face reference support and editable generation parameters. New users get 100 free credits.

- Website: https://cv.cm/v

Description is 40 characters (within the 50-char limit). Thanks for maintaining this list!