### PR TITLE
Add AnswerLens to SEO tools

### DIFF
--- a/Category/SEO.md
+++ b/Category/SEO.md
@@ -9,6 +9,7 @@ A curated list of AI-powered tools for seo. Contribute to this list via our [Con
 | LinkActions | AI-Powered Marketing for Law Firms | [https://www.linkactions.com/](https://www.linkactions.com/) |
 | Seomaker.ai | AI Content Generator for Faster SEO & Marketing | [https://seomaker.ai/](https://seomaker.ai/) |
 | Stevie AI | The Easy & Affordable SEO Tool for Startups | [https://aicenter.ai/stevie](https://aicenter.ai/stevie) |
+| AnswerLens | AI audits for B2B SaaS page evidence | [https://app.sfdj.net/](https://app.sfdj.net/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds AnswerLens to Category/SEO.md.

Disclosure: I am connected to AnswerLens.

The entry follows the table format and links to the homepage. It describes AnswerLens as a B2B SaaS public-evidence audit tool, without ranking, traffic, AI citation, sponsorship, affiliate, or paid-placement claims.