### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/Category/AI_Agent.md
+++ b/Category/AI_Agent.md
@@ -9,6 +9,7 @@ A curated list of AI-powered tools for ai agent. Contribute to this list via our
 | Manus AI | Manus AI  General AI Agent for Task Automation | [https://www.manus.im](https://www.manus.im) |
 | Duelin' Agents | Real-Time AI Conversations and Debates | [https://duelinagent.com/](https://duelinagent.com/) |
 | Knowly AI | AI Agent Automation | [https://goknowly.ai/](https://goknowly.ai/) |
+| Tree Ring Memory | Local-first memory lifecycle for AI agents | [https://terminallylazy.github.io/Tree-Ring-Memory/](https://terminallylazy.github.io/Tree-Ring-Memory/) |
 | Quell | UAT AI Agents | [https://www.quellit.ai/](https://www.quellit.ai/) |
 | XMACNA Funcionarios Digitais com IA | AI digital workers for business automation | [https://xmacna.ai/funcionarios-digitais](https://xmacna.ai/funcionarios-digitais) |
 


### PR DESCRIPTION
## Summary
- add Tree Ring Memory to the AI Agent category
- describe it as local-first memory lifecycle infrastructure for AI agents

## Checks
- Description is 42 characters, under the 50-character guideline
- `git diff --check` passes
- Landing page returns HTTP 200

Tree Ring Memory: https://terminallylazy.github.io/Tree-Ring-Memory/