### PR TITLE
PinZheng(docs): add codex-profiles to developer tools

### DIFF
--- a/Category/Developer_Tools.md
+++ b/Category/Developer_Tools.md
@@ -8,6 +8,7 @@ A curated list of AI-powered tools for developer tools. Contribute to this list 
 | Supabase | Supabase: The Open-Source Firebase Alternative with Scalable Pricing | [https://supabase.com/](https://supabase.com/) |
 | Pullpo | Pullpo: Improve Code Reviews with Developer Feedback & Metrics | [https://pullpo.io/](https://pullpo.io/) |
 | AI Developer Toolkit | 32+ AI prompts for code review, debugging & testing | [https://money-monkey-26.github.io/ai-dev-toolkit/](https://money-monkey-26.github.io/ai-dev-toolkit/) |
+| codex-profiles | Manage separate Codex and ChatGPT profiles | [https://github.com/Ducksss/codex-profiles](https://github.com/Ducksss/codex-profiles) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## Summary

Adds [codex-profiles](https://github.com/Ducksss/codex-profiles) to `Category/Developer_Tools.md` using the existing three-column table format.

codex-profiles is a free, MIT-licensed utility for managing named Codex CLI homes and separate ChatGPT Desktop windows. It is directly relevant to developers who use Codex across multiple local contexts.

## Validation

- Confirmed there is no existing entry or submission.
- Kept the description within the documented 50-character limit.
- Confirmed the source URL is reachable and the diff has no whitespace errors.
