### PR TITLE
Add Open Agent Relay

### DIFF
--- a/Category/Open_Source_AI_Agent_Runtime_Environment.md
+++ b/Category/Open_Source_AI_Agent_Runtime_Environment.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for open source ai agent runtime environment.
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Kodosumi | Scale AI Agents with Ray | [https://www.kodosumi.io/](https://www.kodosumi.io/) |
+| Open Agent Relay | Share local agents over trusted LANs | [GitHub](https://github.com/ShakespeareLabs/open-agent-relay) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds Open Agent Relay to the Open Source AI Agent Runtime Environment category.

The description is under 50 characters and links directly to the Apache-2.0 repository. Open Agent Relay lets teams expose an existing local agent over a trusted LAN while its code and credentials remain on the host.