### PR TITLE
Add Aural to AI Interview tools

### DIFF
--- a/Category/AI_Interview.md
+++ b/Category/AI_Interview.md
@@ -4,6 +4,7 @@ A curated list of AI-powered tools for ai interview. Contribute to this list via
 
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
+| Aural | Open-source voice, chat and video interviews | [https://github.com/1146345502/aural-oss](https://github.com/1146345502/aural-oss) |
 | Opground | Land Your Dream Tech Job Faster with AI-Powered Matching | [https://opground.com/](https://opground.com/) |
 
 ## More Resources


### PR DESCRIPTION
Adds Aural to the AI Interview category using the required table format.

- Name: Aural
- Description: Open-source voice, chat and video interviews
- Link: https://github.com/1146345502/aural-oss
- Category: AI Interview

The description is 44 characters, within the 50-character limit.