### PR TITLE
docs: add Marketing Studio to AI-powered video ad creators

### DIFF
--- a/Category/AI-Powered_Video_Ad_Creator.md
+++ b/Category/AI-Powered_Video_Ad_Creator.md
@@ -1,4 +1,5 @@
-# AI-Powered Video Ad Creator Tools
+Glato AI# AI-Powered Video Ad Creator Tools
+| Marketing Studio | Open-source AI video ad studio | [GitHub](https://github.com/AtlasCloudAI/atlas-marketing-studio) |
 
 A curated list of AI-powered tools for ai-powered video ad creator. Contribute to this list via our [Contributing Guidelines](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/CONTRIBUTING.md).
 


### PR DESCRIPTION
Adds Marketing Studio to the AI-Powered Video Ad Creator category. It is an MIT-licensed, self-hostable AI video ad studio for e-commerce creative workflows. Contributing on behalf of AtlasCloudAI.