### PR TITLE
Add Vedic Astrology Chart to AI astrology tools

### DIFF
--- a/Category/AI_Astrology.md
+++ b/Category/AI_Astrology.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for ai astrology. Contribute to this list via
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Jeffrey Celavie AI | Jeffrey Celavie AI-Powered Astro-Coaching Assistant for Personalized Astrology | [https://www.jeffreycelavie.team](https://www.jeffreycelavie.team) |
+| Vedic Astrology Chart | Generate and interpret Vedic birth charts | [https://vedicastrologychart.net](https://vedicastrologychart.net) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds Vedic Astrology Chart to the AI Astrology category with a concise description and its canonical website URL.