### PR TITLE
Add Echo99 to Meeting Assistant tools

### DIFF
--- a/Category/Meeting_Assistant.md
+++ b/Category/Meeting_Assistant.md
@@ -7,6 +7,7 @@ A curated list of AI-powered tools for meeting assistant. Contribute to this lis
 | RequirementsAI | AI-Powered Requirements Generator | [https://requirementsai.com/Home](https://requirementsai.com/Home) |
 | Otter.AI | The Ultimate AI Meeting Assistant for Businesses | [https://www.otter.ai/](https://www.otter.ai/) |
 | Meeting.ai | Transcribe, Summarize, Analyze Meetings | [https://meeting.ai/](https://meeting.ai/) |
+| Echo99 | Private Mac recorder with local transcription | [https://www.echo99.app/](https://www.echo99.app/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## Summary

Add Echo99 to the Meeting Assistant category.

Echo99 is a private macOS call recorder with local transcription and speaker labeling.

## Why it fits

- records microphone and system audio as separate tracks
- transcribes and labels speakers on-device
- works without a meeting bot or account
- keeps recordings and transcripts on the Mac

## Validation

- `git diff --check`
- confirmed the description is 45 characters, below the 50-character limit
- confirmed the Echo99 website returns HTTP 200
- checked for an existing Echo99 entry or submission
