### PR TITLE
Add TaroMind AI to AI Astrology tools

### DIFF
--- a/Category/AI_Astrology.md
+++ b/Category/AI_Astrology.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for ai astrology. Contribute to this list via
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Jeffrey Celavie AI | Jeffrey Celavie AI-Powered Astro-Coaching Assistant for Personalized Astrology | [https://www.jeffreycelavie.team](https://www.jeffreycelavie.team) |
+| TaroMind AI | AI tarot reflection tool by Xiangce Sun | [https://taromindai.com/yes-or-no-tarot](https://taromindai.com/yes-or-no-tarot) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## Summary
- Add TaroMind AI to the AI Astrology category.
- The entry links to the public Yes or No Tarot tool.

## Disclosure
TaroMind AI is submitted by its creator, Xiangce Sun. The tool is free for reflective use and does not claim deterministic predictions.