### PR TITLE
Add ImageChanger to AI Image Editor tools

### DIFF
--- a/Category/AI_Image_Editor.md
+++ b/Category/AI_Image_Editor.md
@@ -10,6 +10,7 @@ A curated list of AI-powered tools for ai image editor. Contribute to this list 
 | Profile Pic Maker | PFP Maker : Free AI Profile Picture Generator for Professional & Creative Use | [https://pfpmaker.com/](https://pfpmaker.com/) |
 | Remaker AI | Ultimate Face Swap, Video Editing, & AI Image Enhancement | [https://remaker.ai/](https://remaker.ai/) |
 | ClearCrowds | AI cleanup for crowds, objects, glare | [https://www.clearcrowds.com](https://www.clearcrowds.com) |
+| ImageChanger | AI photo editing with 38 focused workflows | [https://aiimagechanger.app/](https://aiimagechanger.app/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds ImageChanger to the AI Image Editor category with its canonical website and a concise factual description.

This changes one directory row only.

Validation: `git diff --check`