### PR TITLE
Add Transcreve BR to Audio Processing

### DIFF
--- a/Category/Audio_Processing.md
+++ b/Category/Audio_Processing.md
@@ -6,6 +6,7 @@ A curated list of AI-powered tools for audio processing. Contribute to this list
 |-----------|----------------------------|---------|
 | LALAL.AI | The Powerful AI Tool for Separating Vocals, Instruments & More | [https://www.lalal.ai/](https://www.lalal.ai/) |
 | Toggle Studio | AI mixing and mastering for vocals and beats | [https://toggle.town/studio](https://toggle.town/studio) |
+| Transcreve BR | PT-BR transcription with speaker diarization | [https://www.brainiall.com/transcreve/transcricao](https://www.brainiall.com/transcreve/transcricao) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds Transcreve BR to the Audio Processing category with a factual 44-character description and the live corporate product URL.

Validation: URL returns HTTP 200; Markdown diff check passes.