### PR TITLE
Add YingTu to AI Image Generation tools

### DIFF
--- a/Category/AI_Image_Generation.md
+++ b/Category/AI_Image_Generation.md
@@ -6,6 +6,7 @@ A curated list of AI-powered tools for ai image generation. Contribute to this l
 |-----------|----------------------------|---------|
 | AI2Image | Fun AI Image Generator | [https://www.ai2image.com/](https://www.ai2image.com/) |
 | Avyn AI | AI image generation and editing platform | [https://www.avynai.com/](https://www.avynai.com/) |
+| YingTu | AI image and video API route playground | [https://yingtu.ai/en](https://yingtu.ai/en) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds YingTu to the AI Image Generation category with one concise table row and the canonical product URL.

Validation:
- changed only `Category/AI_Image_Generation.md`
- description is 39 characters, within the 50-character limit
- confirmed `https://yingtu.ai/en` is live and no existing YingTu entry was present
- no affiliate link, pricing claim, ranking claim, or unrelated edit

Disclosure: submitting on behalf of the YingTu project. This contribution was prepared with Codex assistance.