### PR TITLE
Add Jobvetta to Career Tools

### DIFF
--- a/Category/Career.md
+++ b/Category/Career.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for career. Contribute to this list via our [
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Braudit AI | Get Free Career Insights & Guidance with Braudit | [https://braudit.app/](https://braudit.app/) |
+| Jobvetta | Search India jobs from official career pages | [https://www.jobvetta.com/](https://www.jobvetta.com/) |
 | ProfileReadme | Template-driven profile pages and developer bio builder | [https://f726103e.profilereadme.pages.dev](https://f726103e.profilereadme.pages.dev) |
 
 ## More Resources


### PR DESCRIPTION
## Summary

Adds Jobvetta to the Career Tools category.

Jobvetta provides an MCP server and REST API for searching current India job openings gathered from official employer career pages. The entry uses the official homepage, stays within the category's 50-character description limit, and is placed alphabetically.

## Checks

- [x] Official URL is live
- [x] Description is concise and factual
- [x] Entry is in the relevant category
- [x] No duplicate Jobvetta entry or pull request was found
