### PR TITLE
Add VideoGen to AI Video Tools

### DIFF
--- a/Category/AI_Video.md
+++ b/Category/AI_Video.md
@@ -10,6 +10,7 @@ A curated list of AI-powered tools for ai video. Contribute to this list via our
 | Rask AI | Translate & Dub Videos in 130+ Languages | [https://www.rask.ai/](https://www.rask.ai/) |
 | Cloud Clipboard Video | Queue-free Seedance 2.0 video, real-face | [https://cv.cm/v](https://cv.cm/v) |
 | Video Upscaler | AI video upscaler for sharper HD video | [https://videoupscaler.video](https://videoupscaler.video) |
+| VideoGen | AI video generator: script to video | [https://videogen.io/ai-video-generator](https://videogen.io/ai-video-generator) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds VideoGen (https://videogen.io/ai-video-generator) to the AI Video category.

VideoGen (Y Combinator-backed) turns prompts, scripts, and articles into finished videos with AI voiceover, subtitles, and b-roll, using Sora, Veo, Kling, and other models. Free plan available; paid from $12/mo. Description kept within the 50-character limit; no duplicate in the category.