### PR TITLE
Add ExtraBrain to AI Interview Tools

### DIFF
--- a/Category/AI_Interview.md
+++ b/Category/AI_Interview.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for ai interview. Contribute to this list via
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Opground | Land Your Dream Tech Job Faster with AI-Powered Matching | [https://opground.com/](https://opground.com/) |
+| ExtraBrain | AI copilot for technical and behavioral interviews | [https://extrabrain.app](https://extrabrain.app) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## What this adds

Adds ExtraBrain to the requested section.

ExtraBrain is a publicly available macOS-first AI copilot for live interviews and technical meetings. It combines live transcription, selected screen context, built-in coding, system-design, behavioral, and meeting profiles, local Parakeet speech-to-text, and user-configured AI providers.

## Why it fits this list

- Shipped macOS application with a public download page.
- Directly matches this list’s category for live interview, meeting, or productivity tools.
- The proposed entry is factual and links to the canonical homepage.

## Disclosure

I am affiliated with ExtraBrain.

## Checks

- [x] Searched for an existing ExtraBrain entry
- [x] Used the repository’s required format and ordering
- [x] Used a direct, non-affiliate URL
- [x] Avoided unsupported privacy, performance, or “best” claims