### PR TITLE
Add ReplacedByAI to Career category

### DIFF
--- a/Category/Career.md
+++ b/Category/Career.md
@@ -6,6 +6,7 @@ A curated list of AI-powered tools for career. Contribute to this list via our [
 |-----------|----------------------------|---------|
 | Braudit AI | Get Free Career Insights & Guidance with Braudit | [https://braudit.app/](https://braudit.app/) |
 | ProfileReadme | Template-driven profile pages and developer bio builder | [https://f726103e.profilereadme.pages.dev](https://f726103e.profilereadme.pages.dev) |
+| ReplacedByAI | Free AI replacement risk score for 1,000+ jobs | [https://www.replacedbai.com](https://www.replacedbai.com) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds **ReplacedByAI** to `Category/Career.md`.

**What it is:** a free tool that scores how exposed a given occupation is to AI replacement, covering 1,000+ occupations, with a career-transition and reskilling guide per role. No signup required to see a score.

**Why the Career category:** it sits alongside Braudit AI as a career-guidance tool rather than a resume/interview generator, so it doesn't duplicate `AI_Resume_Generator` or `AI_Interview`.

**Per CONTRIBUTING:**
- Added to the appropriate category file under `Category/`, one row, existing table style.
- Description is 46 characters (under the 50-char guideline).
- URL verified live before submitting — `https://www.replacedbai.com` returns `200`.
- No affiliate link, no tracking parameters, no other files touched.

Disclosure: I maintain the site. Happy to reword or drop it if it isn't a fit.
