### PR TITLE
Add Hexis to AI Agent tools

### DIFF
--- a/Category/AI_Agent.md
+++ b/Category/AI_Agent.md
@@ -11,6 +11,7 @@ A curated list of AI-powered tools for ai agent. Contribute to this list via our
 | Knowly AI | AI Agent Automation | [https://goknowly.ai/](https://goknowly.ai/) |
 | Quell | UAT AI Agents | [https://www.quellit.ai/](https://www.quellit.ai/) |
 | XMACNA Funcionarios Digitais com IA | AI digital workers for business automation | [https://xmacna.ai/funcionarios-digitais](https://xmacna.ai/funcionarios-digitais) |
+| Hexis | Git-backed skills, tools, and agent context | [https://github.com/Bevel-Software/Hexis](https://github.com/Bevel-Software/Hexis) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds Hexis to the AI Agent category.

The entry links to the public repository and uses a 43-character factual description, within the 50-character category limit.

Validation:
- Repository link returns 200
- No existing Hexis entry or pull request
- Table formatting is unchanged
- git diff --check passes