### PR TITLE
Add IELTS Writing Checker

### DIFF
--- a/Category/AI_Essay_Checker.md
+++ b/Category/AI_Essay_Checker.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for ai essay checker. Contribute to this list
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | EssayCheck | AI Writing & Plagiarism Tool | [https://essaycheck.ai/](https://essaycheck.ai/) |
+| IELTS Writing Checker | IELTS Task 1 and Task 2 writing feedback | [https://ieltswritingchecker.org/](https://ieltswritingchecker.org/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## Summary

Add IELTS Writing Checker to the AI Essay Checker category.

## Why

The tool reviews IELTS Academic Task 1, General Training Task 1, and Task 2 writing, so it fits the category's essay-feedback scope.

Disclosure: I maintain IELTS Writing Checker.

## Validation

- kept the description within the 50-character limit (40 characters)
- confirmed the website returns HTTP 200
- ran `git diff --check`
- confirmed the URL is not already present in this repository
