### PR TITLE
Add SandBase CLI to Developer Tools

### DIFF
--- a/Category/Developer_Tools.md
+++ b/Category/Developer_Tools.md
@@ -8,7 +8,7 @@ A curated list of AI-powered tools for developer tools. Contribute to this list 
 | Supabase | Supabase: The Open-Source Firebase Alternative with Scalable Pricing | [https://supabase.com/](https://supabase.com/) |
 | Pullpo | Pullpo: Improve Code Reviews with Developer Feedback & Metrics | [https://pullpo.io/](https://pullpo.io/) |
 | AI Developer Toolkit | 32+ AI prompts for code review, debugging & testing | [https://money-monkey-26.github.io/ai-dev-toolkit/](https://money-monkey-26.github.io/ai-dev-toolkit/) |
-| SandBase CLI | MCP bridge to 2,000+ AI models and APIs | [https://github.com/sandbaseai/cli](https://github.com/sandbaseai/cli) |
+| SandBase CLI | MCP bridge to 2,000+ AI models | [https://github.com/sandbaseai/cli](https://github.com/sandbaseai/cli) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)

--- a/Category/Developer_Tools.md
+++ b/Category/Developer_Tools.md
@@ -8,6 +8,7 @@ A curated list of AI-powered tools for developer tools. Contribute to this list 
 | Supabase | Supabase: The Open-Source Firebase Alternative with Scalable Pricing | [https://supabase.com/](https://supabase.com/) |
 | Pullpo | Pullpo: Improve Code Reviews with Developer Feedback & Metrics | [https://pullpo.io/](https://pullpo.io/) |
 | AI Developer Toolkit | 32+ AI prompts for code review, debugging & testing | [https://money-monkey-26.github.io/ai-dev-toolkit/](https://money-monkey-26.github.io/ai-dev-toolkit/) |
+| SandBase CLI | MCP bridge to 2,000+ AI models and APIs | [https://github.com/sandbaseai/cli](https://github.com/sandbaseai/cli) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## What

Adds SandBase CLI to the Developer Tools category.

## Why it fits

SandBase CLI is an Apache-2.0 CLI and MCP bridge that connects supported coding-agent clients to a hosted catalog of 2,000+ models and APIs through six tools. The `@sandbaseai/cli` npm package recorded 1,776 downloads in the latest completed monthly reporting window and 109 in the latest completed week.

## Validation

- Only `Category/Developer_Tools.md` changed
- Description is 39 characters, below the 50-character limit
- URL is public and accessible
- `git diff --check` passes

Disclosure: I am affiliated with SandBase. AI assistance was used to prepare this contribution.