### PR TITLE
Add IdeaHunter

### DIFF
--- a/Category/Research_Assistant.md
+++ b/Category/Research_Assistant.md
@@ -7,6 +7,7 @@ A curated list of AI-powered tools for research assistant. Contribute to this li
 | AnswerThis | Your AI-Powered Research Assistant & Summarizer | [https://answerthis.io/](https://answerthis.io/) |
 | Elicit | The AI Research Assistant That Summarizes Papers & Extracts Data in Seconds | [https://elicit.com/](https://elicit.com/) |
 | NotebookLM | AI Research Assistant by Google | [https://notebooklm.google/](https://notebooklm.google/) |
+| IdeaHunter | Startup idea research from demand signals | [https://ideahunter.today](https://ideahunter.today) |
 | NoodleTools | NoodleTools - Research Management & Citation Platform for Students and Educators | [https://www.noodletools.com/](https://www.noodletools.com/) |
 
 ## More Resources


### PR DESCRIPTION
Adds IdeaHunter to the Research Assistant category.\n\nIdeaHunter helps solo founders research demand-backed app and micro-SaaS ideas using public market signals, buyer pain, MVP scope, validation steps, and monetization paths.\n\nValidation:\n- Verified https://ideahunter.today returns HTTP 200.\n- Kept the existing category table format and concise description style.\n\nDisclosure: submitted by an authorized agent for IdeaHunter. No payment, CAPTCHA, email verification, phone, address, or reciprocal backlink required.