### PR TITLE
Add videos.social to Text to Video

### DIFF
--- a/Category/Text_to_Video.md
+++ b/Category/Text_to_Video.md
@@ -6,6 +6,7 @@ A curated list of AI-powered tools for text to video. Contribute to this list vi
 |-----------|----------------------------|---------|
 | Kaiber AI | Create Stunning Videos from Text & Photos with Kaiber's AI Art Tool | [https://kaiber.ai/](https://kaiber.ai/) |
 | CopyCopter | The AI Text-to-Video Tool for Blog Posts & Articles | [https://copycopter.ai/](https://copycopter.ai/) |
+| videos.social | Editable faceless video from blogs | [https://videos.social/?utm_source=toolkitly-awesome&utm_medium=directory&utm_campaign=listing-wave-d](https://videos.social/?utm_source=toolkitly-awesome&utm_medium=directory&utm_campaign=listing-wave-d) |
 | Viva AI | Transform Text Prompts into Stunning Visuals | [https://vivago.ai/](https://vivago.ai/) |
 | Lumalabs.AI | Turn Your Photos into High-Quality Videos | [https://lumalabs.ai/](https://lumalabs.ai/) |
 | Kling AI Kuaishou | Revolutionize Text-to-Video Creation | [https://kling.kuaishou.com/en](https://kling.kuaishou.com/en) |


### PR DESCRIPTION
Adds videos.social under **Text to Video**, next to CopyCopter (blog posts & articles).

videos.social turns blogs, PDFs, and prompts into editable faceless videos (script, scenes, voiceover) rather than a locked regenerate loop. Start free — 1 render included. Packs from $10. 1 credit = 1 render.

Public, usable product in the same class as CopyCopter (text/blog to video). Not a duplicate.

Disclosure: submitted by the videos.social team.