### PR TITLE
Add Agent QA to developer tools

### DIFF
--- a/Category/Developer_Tools.md
+++ b/Category/Developer_Tools.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for developer tools. Contribute to this list 
 
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
+| Agent QA | Natural-language web and mobile app testing | [https://github.com/vostride/agent-qa](https://github.com/vostride/agent-qa) |
 | Supabase | Supabase: The Open-Source Firebase Alternative with Scalable Pricing | [https://supabase.com/](https://supabase.com/) |
 | Pullpo | Pullpo: Improve Code Reviews with Developer Feedback & Metrics | [https://pullpo.io/](https://pullpo.io/) |
 | AI Developer Toolkit | 32+ AI prompts for code review, debugging & testing | [https://money-monkey-26.github.io/ai-dev-toolkit/](https://money-monkey-26.github.io/ai-dev-toolkit/) |


### PR DESCRIPTION
## Summary

Add [Agent QA](https://github.com/vostride/agent-qa) to the Developer Tools category.

The entry describes its core use directly: natural-language web and mobile application testing. Its 43-character description remains within the category's 50-character limit.

## Validation

- verified the canonical project URL and the description against the project documentation
- checked that Agent QA was not already listed or proposed in this repository
- followed the category table schema and ran `git diff --check`

## Disclosure

I am affiliated with Agent QA and Vostride. Agent QA's current FSL-1.1-ALv2 release is source-available, not OSI open source; each release converts to Apache-2.0 after two years. Separate model, browser, or device-provider costs may apply.
