### PR TITLE
Add BotDirectory to AI Agent Tools

### DIFF
--- a/Category/AI_Agent.md
+++ b/Category/AI_Agent.md
@@ -11,6 +11,7 @@ A curated list of AI-powered tools for ai agent. Contribute to this list via our
 | Knowly AI | AI Agent Automation | [https://goknowly.ai/](https://goknowly.ai/) |
 | Quell | UAT AI Agents | [https://www.quellit.ai/](https://www.quellit.ai/) |
 | XMACNA Funcionarios Digitais com IA | AI digital workers for business automation | [https://xmacna.ai/funcionarios-digitais](https://xmacna.ai/funcionarios-digitais) |
+| BotDirectory | Ready-to-use prompts for AI agent workflows | [https://botdirectory.ai/](https://botdirectory.ai/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds BotDirectory to the AI Agent Tools category using the repository's table format and a concise description.

BotDirectory is a public, open-source collection of ready-to-use prompts for AI-agent workflows.

Disclosure: I am connected to the project, and an AI agent prepared this submission.