### PR TITLE
Add SEELE TV to AI video tools

### DIFF
--- a/Category/AI_Video.md
+++ b/Category/AI_Video.md
@@ -8,6 +8,7 @@ A curated list of AI-powered tools for ai video. Contribute to this list via our
 | Hailuo AI | AI Video Creation | [https://hailuoai.video/](https://hailuoai.video/) |
 | PVID | Free AI video generator | [https://pvid.app/](https://pvid.app/) |
 | Rask AI | Translate & Dub Videos in 130+ Languages | [https://www.rask.ai/](https://www.rask.ai/) |
+| SEELE TV | Cinematic video with camera control | [https://seele.tv/](https://seele.tv/) |
 | Cloud Clipboard Video | Queue-free Seedance 2.0 video, real-face | [https://cv.cm/v](https://cv.cm/v) |
 | Video Upscaler | AI video upscaler for sharper HD video | [https://videoupscaler.video](https://videoupscaler.video) |
 


### PR DESCRIPTION
Adds SEELE TV to the AI Video Tools section using the existing list format.\n\nSEELE TV is a cinematic AI video studio focused on scene consistency and shot-level camera control. The entry links to the official product site and uses a concise, factual description.