### PR TITLE
Add AdMapix to advertising tools

### DIFF
--- a/Category/Advertising.md
+++ b/Category/Advertising.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for advertising. Contribute to this list via 
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | M1-project | Your AI Marketing Co-Pilot - Streamline & Grow Your Business | [https://m1-project.com/](https://m1-project.com/) |
+| AdMapix | AI ad intelligence for competitor research | [https://www.admapix.com/](https://www.admapix.com/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Add AdMapix to the Advertising Tools category.

AdMapix is an AI ad intelligence platform for competitor research across mobile games, apps, and ecommerce. The entry uses the official website and follows the category format and 50-character description limit.