### PR TITLE
Add Wordsmith to AI Writing tools

### DIFF
--- a/Category/AI_Writing.md
+++ b/Category/AI_Writing.md
@@ -6,6 +6,7 @@ A curated list of AI-powered tools for ai writing. Contribute to this list via o
 |-----------|----------------------------|---------|
 | Seapik | Seapik AI Content Creator | [https://www.seapik.com/](https://www.seapik.com/) |
 | InstaText | Write Like a Native Speaker with AI Editing | [https://instatext.io/](https://instatext.io/) |
+| Wordsmith | Whole-manuscript developmental editor | [https://wordsmith.page/](https://wordsmith.page/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Wordsmith (https://wordsmith.page/) reads complete manuscripts and returns developmental feedback grounded in the writer's text. More than 100 writers are already writing with us. This pull request adds one factual entry to the AI Writing table under the repository's 50-character limit. The link has no affiliate or tracking parameters. Would this fit the list? If not a fit, please close it and we will leave it there.

Disclosure: this submission is from the product team and was prepared with Codex assistance.
