### PR TITLE
Add Luphra to 3D Generative AI tools

### DIFF
--- a/Category/3D_Generative_AI.md
+++ b/Category/3D_Generative_AI.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for 3d generative ai. Contribute to this list
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Rodin AI | Hyper 3D: Text to 3D Unreal Engine | [https://hyper3d.ai/](https://hyper3d.ai/) |
+| Luphra | Prompt-to-matter: text/sketch to 3D | [https://www.luphra.com/](https://www.luphra.com/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds [Luphra](https://www.luphra.com/) to `Category/3D_Generative_AI.md` next to Rodin AI.

Luphra is prompt-to-matter: AI that turns prompts/sketches into editable 3D and manufactured physical products, starting with 3D printables.

Website: https://www.luphra.com/