### PR TITLE
Add XiuRouter to AI inference platforms

### DIFF
--- a/Category/AI_Inference_Platform.md
+++ b/Category/AI_Inference_Platform.md
@@ -6,6 +6,7 @@ A curated list of AI-powered tools for ai inference platform. Contribute to this
 |-----------|----------------------------|---------|
 | nCompass Technologies | AI Inference Platform | [https://ncompass.tech/](https://ncompass.tech/) |
 | RunAPI | OpenAI-compatible multi-model AI API | [https://runapi.ai](https://runapi.ai) |
+| XiuRouter | Multi-model API with native provider protocols | [https://router.xiu.ai/](https://router.xiu.ai/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## Summary

- add XiuRouter to the AI Inference Platform category
- use a concise description within the 50-character limit
- link to the canonical product URL

## Verification

- confirmed there is no existing XiuRouter or router.xiu.ai entry
- confirmed https://router.xiu.ai/ returns HTTP 200
- `git diff --check` passes