### PR TITLE
Add StudyArena to AI Education

### DIFF
--- a/Category/AI_Education.md
+++ b/Category/AI_Education.md
@@ -19,6 +19,7 @@ A curated list of AI-powered tools for ai education. Contribute to this list via
 | SPOT LMS | Create Engaging Online Courses for Free | [https://www.spotlms.us/](https://www.spotlms.us/) |
 | IApptitudes | The AI-Powered Teaching Assistant for Busy Educators | [https://www.iapptitudes.com/](https://www.iapptitudes.com/) |
 | ProfessorAI | Ace AP Exams with ProfessorAI: Your AI-Powered Study Partner | [https://www.professorai.co/](https://www.professorai.co/) |
+| StudyArena | Free blind AI answer comparisons for students. | [https://studyarena.com](https://studyarena.com) |
 | StudyFetch | AI Study Tools & Personalized Tutor | [https://www.studyfetch.com/](https://www.studyfetch.com/) |
 | Brainly AI | Your AI Learning Companion for Homework, Test Prep, and More | [https://brainly.com/](https://brainly.com/) |
 | Porosheets | Revolutionize Education with AI-Powered Learning | [https://www.porosheets.com/](https://www.porosheets.com/) |


### PR DESCRIPTION
I’ve been working on StudyArena so students can compare several AI answers before seeing which models produced them.

I added one short line to the AI Education category. The three-answer comparison, voting, and model reveal are free.