### PR TITLE
Add BrandQuill to Document Editor tools

### DIFF
--- a/Category/Document_Editor.md
+++ b/Category/Document_Editor.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for document editor. Contribute to this list 
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | Type AI | Write Smarter, Faster | [https://type.ai/](https://type.ai/) |
+| BrandQuill | Turn AI drafts into branded Word documents | [https://brandquill.app](https://brandquill.app) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
## Summary

Adds BrandQuill to the Document Editor category.

BrandQuill turns AI-generated drafts into branded Word documents using a reusable DOCX template. The entry follows the existing table format, links directly to the product, and keeps the description under 50 characters.

Disclosure: this submission is from the BrandQuill maintainer account.