### PR TITLE
Add ResumeAI to AI Resume Generator

### DIFF
--- a/Category/AI_Resume_Generator.md
+++ b/Category/AI_Resume_Generator.md
@@ -5,6 +5,7 @@ A curated list of AI-powered tools for ai resume generator. Contribute to this l
 | Tool Name | Description (max 50 chars) | Website |
 |-----------|----------------------------|---------|
 | ThisResumeDoesNotExist AI | ThisResumeDoesNotExist: Free AI Resume Generator | [https://thisresumedoesnotexist.com/](https://thisresumedoesnotexist.com/) |
+| ResumeAI | Free ATS checker + AI resume builder | [https://withresumeai.com/](https://withresumeai.com/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds ResumeAI to **AI Resume Generator** category.

- https://withresumeai.com/
- Free ATS checker (3/day no account, 10/day free account) + AI resume builder

Disclosure: founder. Canonical domain withresumeai.com (not resume.ai).