### PR TITLE
Add LLM Pulse to SEO tools

### DIFF
--- a/Category/SEO.md
+++ b/Category/SEO.md
@@ -10,6 +10,7 @@ A curated list of AI-powered tools for seo. Contribute to this list via our [Con
 | Seomaker.ai | AI Content Generator for Faster SEO & Marketing | [https://seomaker.ai/](https://seomaker.ai/) |
 | Stevie AI | The Easy & Affordable SEO Tool for Startups | [https://aicenter.ai/stevie](https://aicenter.ai/stevie) |
 | AnswerLens | AI audits for B2B SaaS page evidence | [https://app.sfdj.net/](https://app.sfdj.net/) |
+| LLM Pulse | AI search visibility and brand analytics | [https://llmpulse.ai/](https://llmpulse.ai/) |
 
 ## More Resources
 - [Back to Categories](https://github.com/ToolkitlyAI/awesome-ai-tools/blob/master/README.md)


### PR DESCRIPTION
Adds LLM Pulse to the SEO category with one concise entry and the canonical product URL. LLM Pulse measures brand visibility across AI search engines.

Checks completed:
- description is 40 characters, within the 50-character limit
- canonical URL returns HTTP 200
- default branch, issues, and pull requests contain no duplicate
- one category file changed

Disclosure: I am a co-founder of LLM Pulse.